### PR TITLE
Create grand average output directory

### DIFF
--- a/source_contrasts/source_contrasts.py
+++ b/source_contrasts/source_contrasts.py
@@ -272,6 +272,10 @@ def grand_average(
                 freq_band=freq_band,
             )
 
+            # Create output directory if it doesn't already exist
+            assert isinstance(paths["output_dir"], Path)
+            paths["output_dir"].mkdir(exist_ok=True)
+
             # Now create a grand average contrast. This is a little hacky
             stc_grand_mean = stc_morphed.copy()
             stc_grand_mean.data = np.array([stc.data for stc in stcs_morphed]).mean(


### PR DESCRIPTION
Fixes #1

@SophieHerbst Could you please check if this works for you? The grand average step should work now even if `sub-average/source_constrasts` doesn't exist